### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ This step builds the software from source.
 <pre>
 git clone git@github.com:cloudera/search.git
 cd search
-#git checkout master
+# git checkout master
 mvn clean package
 ls search-dist/target/*.tar.gz
 </pre>


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
